### PR TITLE
Changed canonical_url to relative_url

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
@@ -75,6 +75,7 @@ class EntityUrl implements ResolverInterface
         if ($urlRewrite) {
             $result = [
                 'id' => $urlRewrite->getEntityId(),
+                'canonical_url' => $urlRewrite->getTargetPath(),
                 'relative_url' => $urlRewrite->getTargetPath(),
                 'type' => $this->sanitizeType($urlRewrite->getEntityType())
             ];

--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
@@ -75,7 +75,7 @@ class EntityUrl implements ResolverInterface
         if ($urlRewrite) {
             $result = [
                 'id' => $urlRewrite->getEntityId(),
-                'canonical_url' => $urlRewrite->getTargetPath(),
+                'relative_url' => $urlRewrite->getTargetPath(),
                 'type' => $this->sanitizeType($urlRewrite->getEntityType())
             ];
         }

--- a/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
@@ -1,14 +1,14 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 
-type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes") {
-    id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
-    canonical_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
-    type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")
-}
-
 type Query {
     urlResolver(url: String!): EntityUrl @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\EntityUrl") @doc(description: "The urlResolver query returns the relative URL for a specified product, category or CMS page")
+}
+
+type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes") {
+    id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
+    relative_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
+    type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")
 }
 
 enum UrlRewriteEntityTypeEnum {

--- a/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
@@ -7,6 +7,7 @@ type Query {
 
 type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `relative_url`, and `type` attributes") {
     id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
+    canonical_url: String @deprecated(reason: "The canonical_url field is deprecated, use relative_url instead.")
     relative_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
     type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")
 }

--- a/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
@@ -5,7 +5,7 @@ type Query {
     urlResolver(url: String!): EntityUrl @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\EntityUrl") @doc(description: "The urlResolver query returns the relative URL for a specified product, category or CMS page")
 }
 
-type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes") {
+type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `relative_url`, and `type` attributes") {
     id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
     relative_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
     type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/UrlRewrite/UrlResolverTest.php
@@ -31,7 +31,7 @@ class UrlResolverTest extends GraphQlAbstract
     }
 
     /**
-     * Tests if target_path(canonical_url) is resolved for Product entity
+     * Tests if target_path(relative_url) is resolved for Product entity
      *
      * @magentoApiDataFixture Magento/CatalogUrlRewrite/_files/product_with_category.php
      */
@@ -60,7 +60,7 @@ class UrlResolverTest extends GraphQlAbstract
   urlResolver(url:"{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -68,12 +68,12 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($product->getEntityId(), $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
     /**
-     * Tests the use case where canonical_url is provided as resolver input in the Query
+     * Tests the use case where relative_url is provided as resolver input in the Query
      *
      * @magentoApiDataFixture Magento/CatalogUrlRewrite/_files/product_with_category.php
      */
@@ -104,7 +104,7 @@ QUERY;
   urlResolver(url:"{$canonicalPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -112,7 +112,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($product->getEntityId(), $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -147,7 +147,7 @@ QUERY;
   urlResolver(url:"{$urlPath2}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -155,7 +155,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($categoryId, $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -183,14 +183,14 @@ QUERY;
   urlResolver(url:"{$requestPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
 QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertEquals($cmsPageId, $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper(str_replace('-', '_', $expectedEntityType)), $response['urlResolver']['type']);
     }
 
@@ -226,7 +226,7 @@ QUERY;
   urlResolver(url:"{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -234,7 +234,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($product->getEntityId(), $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -266,7 +266,7 @@ QUERY;
   urlResolver(url:"{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -307,7 +307,7 @@ QUERY;
   urlResolver(url:"/{$urlPath}")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -315,7 +315,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($categoryId, $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals(strtoupper($expectedType), $response['urlResolver']['type']);
     }
 
@@ -344,7 +344,7 @@ QUERY;
   urlResolver(url:"/")
   {
    id
-   canonical_url
+   relative_url
    type
   }
 }
@@ -352,7 +352,7 @@ QUERY;
         $response = $this->graphQlQuery($query);
         $this->assertArrayHasKey('urlResolver', $response);
         $this->assertEquals($homePageId, $response['urlResolver']['id']);
-        $this->assertEquals($targetPath, $response['urlResolver']['canonical_url']);
+        $this->assertEquals($targetPath, $response['urlResolver']['relative_url']);
         $this->assertEquals('CMS_PAGE', $response['urlResolver']['type']);
     }
 }


### PR DESCRIPTION
### Description (*)
As per the devdoc, there must be a **relative_url** instead of **canonical_url**.
- https://devdocs.magento.com/guides/v2.3/graphql/reference/url-resolver.html

### Fixed Issues (if relevant)
1. N/A

### Manual testing scenarios (*)
1. Try to execute following GraphQl query as explain in docs.
`{
 urlResolver(url:"joust-duffle-bag.html") {
   id
   relative_url
   type
 }
}`
2. It throws following error:
`{
  "errors": [
    {
      "message": "Cannot query field \"relative_url\" on type \"EntityUrl\".",
      "category": "graphql",
      "locations": [
        {
          "line": 4,
          "column": 4
        }
      ]
    }
  ]
}`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)